### PR TITLE
Fixes broken build pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>cloud.eppo</groupId>
-    <artifactId>eppo-server-sdk</artifactId>
-    <version>2.1.0</version>
+    <groupId>com.glossgenius</groupId>
+    <artifactId>eppo-java-server-sdk</artifactId>
+    <version>2.1.0-0.1.1</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>
@@ -76,11 +76,11 @@
     </dependencies>
 
     <distributionManagement>
-        <snapshotRepository>
+        <repository>
             <id>github</id>
             <name>GitHub Packages</name>
             <url>https://maven.pkg.github.com/GlossGenius/eppo-java-server-sdk</url>
-        </snapshotRepository>
+        </repository>
     </distributionManagement>
 	<build>
         <testResources>
@@ -108,17 +108,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>2.2.1</version>
@@ -143,26 +132,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <gpgArguments>
-                        <arg>--pinentry-mode</arg>
-                        <arg>loopback</arg>
-                    </gpgArguments>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Previous PR (#2) missed a few things due to my unfamiliarity with Maven.

This PR should fix some of the previous issues with the build pipeline:
- Removes steps that are not required for our normal build process
- Explicitly sets the build version in `pom.xml`