### PR TITLE
[EN-17858] FetchConfigurationsTask is more fault tolerant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.glossgenius</groupId>
     <artifactId>eppo-java-server-sdk</artifactId>
-    <version>2.1.0-0.2.1</version>
+    <version>2.1.0-0.2.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.glossgenius</groupId>
     <artifactId>eppo-java-server-sdk</artifactId>
-    <version>2.1.0-0.2.0</version>
+    <version>2.1.0-0.2.1</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/src/main/java/com/eppo/sdk/helpers/FetchConfigurationsTask.java
+++ b/src/main/java/com/eppo/sdk/helpers/FetchConfigurationsTask.java
@@ -4,8 +4,10 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @AllArgsConstructor
+@Slf4j
 public class FetchConfigurationsTask extends TimerTask {
 
   private ConfigurationStore configurationStore;
@@ -15,8 +17,16 @@ public class FetchConfigurationsTask extends TimerTask {
 
   @Override
   public void run() {
-    configurationStore.fetchAndSetExperimentConfiguration();
-    long delay = this.intervalInMillis - ((long) Math.random() * this.jitterInMillis);
+    // Uncaught runtime exceptions will prevent this task from being rescheduled.
+    // As a result, the SDK will continue functioning using the in-memory cache, but will never attempt
+    // to synchronize with Eppo Cloud again.
+    try {
+      configurationStore.fetchAndSetExperimentConfiguration();
+    } catch (Exception e) {
+      log.error("[Eppo SDK] Error fetching experiment configuration", e);
+    }
+
+    long delay = this.intervalInMillis - (long) (Math.random() * this.jitterInMillis);
     FetchConfigurationsTask nextTask = new FetchConfigurationsTask(configurationStore, timer, intervalInMillis, jitterInMillis);
     timer.schedule(nextTask, delay);
   }


### PR DESCRIPTION
https://glossgenius.atlassian.net/browse/EN-17858
* Added a `try/catch` in the `FetchConfigurationsTask` to be more fault tolerant
    * Prior to this, any thrown `RuntimeException` would cause the timer thread to crash, and the SDK->EppoCloud connection would be severed, unbeknownst to the SDK user.
* Fixed the jittery calculation. `(long)Math.random()` was always being cast to `0`.