### PR TITLE
Revert "[NO TASK] Log experiment key and values when fetching from Eppo"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.glossgenius</groupId>
     <artifactId>eppo-java-server-sdk</artifactId>
-    <version>2.1.0-0.2.2</version>
+    <version>2.1.0-0.2.1</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.glossgenius</groupId>
     <artifactId>eppo-java-server-sdk</artifactId>
-    <version>2.1.0-0.2.1</version>
+    <version>2.1.0-0.2.3</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
+++ b/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
@@ -5,7 +5,6 @@ import com.eppo.sdk.dto.ExperimentConfigurationResponse;
 import com.eppo.sdk.exception.ExperimentConfigurationNotFound;
 import com.eppo.sdk.exception.NetworkException;
 import com.eppo.sdk.exception.NetworkRequestNotAllowed;
-import lombok.extern.slf4j.Slf4j;
 import org.ehcache.Cache;
 
 import java.util.Map;
@@ -14,7 +13,6 @@ import java.util.Optional;
 /**
  * Configuration Store Class
  */
-@Slf4j
 public class ConfigurationStore {
     Cache<String, ExperimentConfiguration> experimentConfigurationCache;
     ExperimentConfigurationRequestor experimentConfigurationRequestor;
@@ -94,9 +92,6 @@ public class ConfigurationStore {
 
         if (!response.isEmpty()) {
             for (Map.Entry<String, ExperimentConfiguration> entry : response.get().getFlags().entrySet()) {
-
-                log.info("[Eppo SDK] Fetched configuration key=[" + entry.getKey() + "], value=[" + entry.getValue() + "]");
-
                 this.setExperimentConfiguration(entry.getKey(), entry.getValue());
             }
         }


### PR DESCRIPTION
Reverts GlossGenius/eppo-java-server-sdk#7

PR #7 could have been useful to diagnose an incident, but will be _very noisy_ day-to-day. I propose we revert the PR.