### PR TITLE
[NO TASK] Fix oneOf comparisons for both Booleans and Numbers

### DIFF
--- a/src/main/java/com/eppo/sdk/dto/EppoValue.java
+++ b/src/main/java/com/eppo/sdk/dto/EppoValue.java
@@ -118,7 +118,19 @@ public class EppoValue {
             case STRING:
                 return this.stringValue;
             case NUMBER:
-                return this.doubleValue.toString();
+                // By default, `String.valueOf(<double>)` will include at least one decimal place.
+                // Though numeric flags can either be integers or floating-point types. And target
+                // rule logic will cast a number type to a String before evaluating `oneOf` or `notOneOf`
+                // rules.
+                // The logic below ensures the cast to string better represents the intended numeric
+                // field type.
+                //
+                // @see https://docs.geteppo.com/feature-flagging/flag-variations#numeric-flags
+                // @see https://docs.geteppo.com/feature-flagging/targeting#supported-rule-operators
+                if (this.doubleValue.intValue() == this.doubleValue) {
+                    return String.valueOf(this.doubleValue.intValue());
+                }
+                return String.valueOf(this.doubleValue);
             case BOOLEAN:
                 return this.boolValue.toString();
             case ARRAY_OF_STRING:

--- a/src/main/java/com/eppo/sdk/helpers/RuleValidator.java
+++ b/src/main/java/com/eppo/sdk/helpers/RuleValidator.java
@@ -153,9 +153,9 @@ public class RuleValidator {
                         return Compare.compareRegex(value.stringValue(),
                                 Pattern.compile(condition.value.stringValue()));
                     case ONE_OF:
-                        return Compare.isOneOf(value.stringValue(), condition.value.arrayValue());
+                        return Compare.isOneOf(value.toString(), condition.value.arrayValue());
                     case NOT_ONE_OF:
-                        return !Compare.isOneOf(value.stringValue(), condition.value.arrayValue());
+                        return !Compare.isOneOf(value.toString(), condition.value.arrayValue());
                 }
             } catch (Exception e) {
                 return false;

--- a/src/test/java/com/eppo/sdk/helpers/RuleValidatorTest.java
+++ b/src/test/java/com/eppo/sdk/helpers/RuleValidatorTest.java
@@ -71,6 +71,44 @@ class RuleValidatorTest {
         addConditionToRule(rule, condition);
     }
 
+    public void addOneOfConditionWithIntegers(Rule rule) {
+        Condition condition = new Condition();
+        List<String> values = new ArrayList<>();
+        values.add("1");
+        values.add("2");
+
+        condition.value = EppoValue.valueOf(values);
+        condition.attribute = "oneOf";
+        condition.operator = OperatorType.ONE_OF;
+
+        addConditionToRule(rule, condition);
+    }
+
+    public void addOneOfConditionWithDoubles(Rule rule) {
+        Condition condition = new Condition();
+        List<String> values = new ArrayList<>();
+        values.add("1.5");
+        values.add("2.7");
+
+        condition.value = EppoValue.valueOf(values);
+        condition.attribute = "oneOf";
+        condition.operator = OperatorType.ONE_OF;
+
+        addConditionToRule(rule, condition);
+    }
+
+    public void addOneOfConditionWithBoolean(Rule rule) {
+        Condition condition = new Condition();
+        List<String> values = new ArrayList<>();
+        values.add("true");
+
+        condition.value = EppoValue.valueOf(values);
+        condition.attribute = "oneOf";
+        condition.operator = OperatorType.ONE_OF;
+
+        addConditionToRule(rule, condition);
+    }
+
     public void addNotOneOfCondition(Rule rule) {
         Condition condition = new Condition();
         List<String> values = new ArrayList<>();
@@ -224,6 +262,62 @@ class RuleValidatorTest {
         subjectAttributes.put("oneOf", EppoValue.valueOf("value1"));
 
         Assertions.assertFalse(RuleValidator.findMatchingRule(subjectAttributes, rules).isPresent());
+    }
+
+    @DisplayName("findMatchingRule() with oneOf rule on a string")
+    @Test
+    void testMatchesAnyRuleWithOneOfRuleOnString() {
+        List<Rule> rules = new ArrayList<>();
+        Rule rule = createRule(new ArrayList<>());
+        addOneOfCondition(rule);
+        rules.add(rule);
+
+        EppoAttributes subjectAttributes = new EppoAttributes();
+        subjectAttributes.put("oneOf", EppoValue.valueOf("value1"));
+
+        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isPresent());
+    }
+
+    @DisplayName("findMatchingRule() with oneOf rule on an integer")
+    @Test
+    void testMatchesAnyRuleWithOneOfRuleOnInteger() {
+        List<Rule> rules = new ArrayList<>();
+        Rule rule = createRule(new ArrayList<>());
+        addOneOfConditionWithIntegers(rule);
+        rules.add(rule);
+
+        EppoAttributes subjectAttributes = new EppoAttributes();
+        subjectAttributes.put("oneOf", EppoValue.valueOf(2));
+
+        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isPresent());
+    }
+
+    @DisplayName("findMatchingRule() with oneOf rule on a double")
+    @Test
+    void testMatchesAnyRuleWithOneOfRuleOnDouble() {
+        List<Rule> rules = new ArrayList<>();
+        Rule rule = createRule(new ArrayList<>());
+        addOneOfConditionWithDoubles(rule);
+        rules.add(rule);
+
+        EppoAttributes subjectAttributes = new EppoAttributes();
+        subjectAttributes.put("oneOf", EppoValue.valueOf(1.5));
+
+        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isPresent());
+    }
+
+    @DisplayName("findMatchingRule() with oneOf rule on a boolean")
+    @Test
+    void testMatchesAnyRuleWithOneOfRuleOnBoolean() {
+        List<Rule> rules = new ArrayList<>();
+        Rule rule = createRule(new ArrayList<>());
+        addOneOfConditionWithBoolean(rule);
+        rules.add(rule);
+
+        EppoAttributes subjectAttributes = new EppoAttributes();
+        subjectAttributes.put("oneOf", EppoValue.valueOf(true));
+
+        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isPresent());
     }
 
 }


### PR DESCRIPTION
NO TASK
* Fixes `oneOf` evaluations for both boolean and number field types

---

Issue was initially reported in [slack](https://glossgenius.slack.com/archives/C04L3DVAX0R/p1715612108035939) (see image below).

It turns out that [Eppo evaluates oneOf](https://docs.geteppo.com/feature-flagging/targeting#supported-rule-operators) by casting booleans and numbers to a string. However, [Eppo recently introduced a change to the stringValue()](https://github.com/Eppo-exp/java-server-sdk/blob/main/src/main/java/com/eppo/sdk/dto/EppoValue.java#L76)  method that will return `null` when the field is a boolean or a string.

![image (1)](https://github.com/GlossGenius/eppo-java-server-sdk/assets/33907262/9d7d9c4b-5bae-4c1b-8c6e-28db3054a72a)
